### PR TITLE
Add MergeFrom Methods to MapField for Dictionary and MapField Merging

### DIFF
--- a/Runtime/Google.Protobuf/Collections/MapField.cs
+++ b/Runtime/Google.Protobuf/Collections/MapField.cs
@@ -82,6 +82,24 @@ namespace Google.Protobuf.Collections
         private readonly LinkedList<KeyValuePair<TKey, TValue>> list = new LinkedList<KeyValuePair<TKey, TValue>>();
 
         /// <summary>
+        /// Merges entries from another <see cref="MapField{TKey, TValue}"/> into this instance.
+        /// </summary>
+        /// <param name="other">
+        /// The <see cref="MapField{TKey, TValue}"/> whose entries will be merged.
+        /// </param>
+        public void MergeFrom(MapField<TKey, TValue> other)
+        {
+            // Reuse the IDictionary<TKey, TValue> MergeFrom implementation
+            MergeFrom((System.Collections.Generic.IDictionary<TKey, TValue>)other);
+        }
+
+        public void MergeFrom(MapField<TKey, TValue> other)
+        {
+            // IDictionary<TKey,TValue> 用の MergeFrom を再利用
+            MergeFrom((System.Collections.Generic.IDictionary<TKey, TValue>)other);
+        }
+
+        /// <summary>
         /// Creates a deep clone of this object.
         /// </summary>
         /// <returns>

--- a/Runtime/Google.Protobuf/Collections/MapField.cs
+++ b/Runtime/Google.Protobuf/Collections/MapField.cs
@@ -82,6 +82,20 @@ namespace Google.Protobuf.Collections
         private readonly LinkedList<KeyValuePair<TKey, TValue>> list = new LinkedList<KeyValuePair<TKey, TValue>>();
 
         /// <summary>
+        /// Merges entries from an <see cref="IDictionary{TKey, TValue}"/> into this instance.
+        /// </summary>
+        /// <param name="other">
+        /// The dictionary whose entries will be merged into this map.
+        /// </param>
+        public void MergeFrom(IDictionary<TKey, TValue> other)
+        {
+            foreach (var kv in other)
+            {
+                this[kv.Key] = kv.Value;
+            }
+        }
+
+        /// <summary>
         /// Merges entries from another <see cref="MapField{TKey, TValue}"/> into this instance.
         /// </summary>
         /// <param name="other">
@@ -90,15 +104,9 @@ namespace Google.Protobuf.Collections
         public void MergeFrom(MapField<TKey, TValue> other)
         {
             // Reuse the IDictionary<TKey, TValue> MergeFrom implementation
-            MergeFrom((System.Collections.Generic.IDictionary<TKey, TValue>)other);
+            MergeFrom((IDictionary<TKey, TValue>)other);
         }
-
-        public void MergeFrom(MapField<TKey, TValue> other)
-        {
-            // IDictionary<TKey,TValue> 用の MergeFrom を再利用
-            MergeFrom((System.Collections.Generic.IDictionary<TKey, TValue>)other);
-        }
-
+        
         /// <summary>
         /// Creates a deep clone of this object.
         /// </summary>


### PR DESCRIPTION
### Summary of Changes
This pull request introduces two new methods to the `MapField<TKey, TValue>` class within the `Runtime/Google.Protobuf/Collections/MapField.cs` file. These methods enhance the functionality by allowing merging operations.

### Changes Introduced
1. **Added Method `MergeFrom(IDictionary<TKey, TValue> other)`**
   - This method enables the merging of entries from an `IDictionary<TKey, TValue>` into the current `MapField` instance.
   - It iterates through the provided dictionary (`other`) and updates the current map with its key-value pairs.

2. **Added Method `MergeFrom(MapField<TKey, TValue> other)`**
   - This method allows the merging of entries from another `MapField<TKey, TValue>` instance.
   - Internally, it reuses the `MergeFrom(IDictionary<TKey, TValue>)` implementation for consistency.

### Benefits
- Simplifies the process of merging data into `MapField` instances.
- Improves code reusability by leveraging a shared implementation for both `IDictionary` and `MapField`.

### Code Changes
Below is a snippet of the added code:
```csharp
/// <summary>
/// Merges entries from an <see cref="IDictionary{TKey, TValue}"/> into this instance.
/// </summary>
/// <param name="other">
/// The dictionary whose entries will be merged into this map.
/// </param>
public void MergeFrom(IDictionary<TKey, TValue> other)
{
    foreach (var kv in other)
    {
        this[kv.Key] = kv.Value;
    }
}

/// <summary>
/// Merges entries from another <see cref="MapField{TKey, TValue}"/> into this instance.
/// </summary>
/// <param name="other">
/// The <see cref="MapField{TKey, TValue}"/> whose entries will be merged.
/// </param>
public void MergeFrom(MapField<TKey, TValue> other)
{
    // Reuse the IDictionary<TKey, TValue> MergeFrom implementation
    MergeFrom((IDictionary<TKey, TValue>)other);
}